### PR TITLE
Bump Setup Typst to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,10 +18,9 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: just
-      - uses: yusancky/setup-typst@v2
-        id: setup-typst
+      - uses: typst-community/setup-typst@v4
         with:
-          version: 'v0.11.0'
+          typst-version: 'v0.11.0'
       - name: Make file executable
         run: chmod +x scripts/build  # Add this step
       - run: |


### PR DESCRIPTION
Bump [`typst-community/setup-typst`](https://github.com/typst-community/setup-typst) to v4

> [!IMPORTANT] 
> The action `yusancky/setup-typst` has officially been migrated to repository `typst-community/setup-typst`. See [announcement](https://github.com/yusancky/setup-typst/blob/main/announcement.md) for more information.